### PR TITLE
fix version requirements for Go and terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Terraform provider for managing your Volterra resources.
 ## Requirements
 ------------
 
--	[Terraform](https://www.terraform.io/downloads.html) = 0.12.x
--	[Go](https://golang.org/doc/install) >= 1.15 (to build the provider plugin)
+-	[Terraform](https://www.terraform.io/downloads.html) >= 0.13.x
+-	[Go](https://golang.org/doc/install) >= 1.16 (to build the provider plugin)
 
 ## Building The Provider
 ------------------------


### PR DESCRIPTION
Fix requirements for Go and Terraform version. The docs https://registry.terraform.io/providers/volterraedge/volterra/latest/docs already mentions Terraform 0.13+

Cc @madhukar32 