### PR TITLE
API Credential Delete

### DIFF
--- a/volterra/resource_volterra_api_credential.go
+++ b/volterra/resource_volterra_api_credential.go
@@ -135,7 +135,7 @@ func resourceVolterraAPICredentialCreate(d *schema.ResourceData, meta interface{
 	}
 
 	rspAPICred := rspProto.(*ves_io_schema_api_credential.CreateResponse)
-	d.SetId(apiCredParams.name)
+	d.SetId(rspAPICred.Name)
 	d.Set("data", rspAPICred.Data)
 	return resourceVolterraAPICredentialRead(d, meta)
 }


### PR DESCRIPTION
This PR allows for API Credentials to be deleted by the provider. This was previously not implemented. 

There are 2 key changes to the API Credential resource:
- The terraform object ``id`` is now the unique identifier returned from the API (this was previously just the 'name' given to the resource).
- The "Delete" method is now implemented so that the credentials will be revoked by the provider (```terraform delete``` or some more specific operation)

I've tested this PR but no coverage in ``resource_volterra_api_credential_test.go`` is provided.